### PR TITLE
Fix /v2 routing for Vercel deployment

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,14 @@ const openai = new OpenAIApi(process.env.OPENAI_API_KEY);
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, "public")));
+
+// Serve v2 static files
+app.use('/v2', express.static(path.join(__dirname, "v2/public-v2")));
+
+// Mount v2 API routes
+const v2Routes = require("./v2/index-v2");
+app.use('/v2/api', v2Routes);
+
 Sentry.init({
   dsn: "https://3df40e009cff002fcf8b9f676bddf9d5@o502926.ingest.us.sentry.io/4507164679405568",
   integrations: [

--- a/v2/index-v2.js
+++ b/v2/index-v2.js
@@ -50,7 +50,7 @@ const db = initializeFirebase();
  * API: Start a new game
  * This triggers the AI to plan and generate the entire world
  */
-app.post("/api/v2/new-game", async (req, res) => {
+app.post("/new-game", async (req, res) => {
   const { userId, userProfile } = req.body;
   
   console.log(`[Server] Starting new game for user ${userId}`);
@@ -110,7 +110,7 @@ app.post("/api/v2/new-game", async (req, res) => {
 /**
  * API: Continue existing game
  */
-app.post("/api/v2/continue-game", async (req, res) => {
+app.post("/continue-game", async (req, res) => {
   const { userId } = req.body;
   
   try {
@@ -236,7 +236,7 @@ io.on("connection", (socket) => {
 /**
  * API: Get world map (for mini-map feature)
  */
-app.get("/api/v2/world-map/:userId", (req, res) => {
+app.get("/world-map/:userId", (req, res) => {
   const userId = req.params.userId;
   const gameEngine = activeGames.get(userId);
   
@@ -265,7 +265,7 @@ app.get("/api/v2/world-map/:userId", (req, res) => {
 /**
  * API: Generate game preview (shows what AI will create)
  */
-app.post("/api/v2/preview-game", async (req, res) => {
+app.post("/preview-game", async (req, res) => {
   const { userProfile } = req.body;
   
   try {
@@ -332,9 +332,14 @@ async function saveWorldToFirebase(userId, world) {
   }
 }
 
-// Start server
-server.listen(PORT, () => {
-  console.log(`Game Server v2 running on port ${PORT}`);
-  console.log(`Architecture: AI-planned, pre-generated worlds`);
-  console.log(`Features: Instant room navigation, rich content, educational focus`);
-});
+// Export for use as a module
+module.exports = app;
+
+// Only start server if run directly (not imported)
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Game Server v2 running on port ${PORT}`);
+    console.log(`Architecture: AI-planned, pre-generated worlds`);
+    console.log(`Features: Instant room navigation, rich content, educational focus`);
+  });
+}

--- a/v2/public-v2/index.html
+++ b/v2/public-v2/index.html
@@ -324,7 +324,7 @@
             
             try {
                 // Generate the game
-                const response = await fetch('/api/v2/new-game', {
+                const response = await fetch('/v2/api/new-game', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ userId, userProfile: profile })
@@ -465,7 +465,7 @@
         });
         
         // Try to continue existing game
-        fetch('/api/v2/continue-game', {
+        fetch('/v2/api/continue-game', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ userId })

--- a/vercel.json
+++ b/vercel.json
@@ -4,32 +4,12 @@
     {
       "src": "index.js",
       "use": "@vercel/node"
-    },
-    {
-      "src": "v2/index-v2.js", 
-      "use": "@vercel/node"
     }
   ],
   "routes": [
     {
-      "src": "/v2/api/(.*)",
-      "dest": "/v2/index-v2.js"
-    },
-    {
-      "src": "/v2/(.*)",
-      "dest": "/v2/public-v2/$1"
-    },
-    {
-      "src": "/v2",
-      "dest": "/v2/public-v2/index.html"
-    },
-    {
-      "src": "/api/(.*)",
-      "dest": "/index.js"
-    },
-    {
       "src": "/(.*)",
-      "dest": "/public/$1"
+      "dest": "/index.js"
     }
   ],
   "env": {


### PR DESCRIPTION
Fixes the 'Cannot GET /v2' error by properly configuring routing.

## Changes
- Updated main index.js to serve v2 static files and API routes
- Modified v2/index-v2.js to export as module
- Fixed API route paths
- Updated frontend fetch URLs
- Simplified vercel.json

## Test
The v2 game should now be accessible at https://grue.is/v2