### PR TITLE
Force polling transport for Vercel

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,14 +107,18 @@ const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
     origin: process.env.NODE_ENV === 'production' 
-      ? ["https://grue.is", "https://www.grue.is"] 
+      ? ["https://grue.is", "https://www.grue.is", "https://grue-is.vercel.app"] 
       : ["http://localhost:3000", "http://localhost:3001"],
-    methods: ["GET", "POST"],
-    credentials: true
+    methods: ["GET", "POST", "OPTIONS"],
+    credentials: true,
+    allowedHeaders: ["content-type"]
   },
-  transports: ['websocket', 'polling'], // Enable both transports
+  transports: ['polling', 'websocket'], // Polling first for Vercel
+  allowEIO3: true, // Allow different engine.io versions
   pingTimeout: 60000, // Increase timeout to prevent disconnections
-  pingInterval: 25000
+  pingInterval: 25000,
+  upgradeTimeout: 30000, // Timeout for upgrade from polling to websocket
+  maxHttpBufferSize: 1e6 // 1MB max buffer size
 });
 app.set('io', io); // Store io instance on the app for access in request handlers
 

--- a/v2/public-v2/index-debug.html
+++ b/v2/public-v2/index-debug.html
@@ -717,16 +717,17 @@
             updateGameState(gameData.initialState);
             updateRoom(gameData.currentRoom);
             
-            // Connect socket with better configuration
+            // Connect socket with Vercel-compatible configuration (polling only)
             debugLog('socket', `Connecting Socket.IO with userId: ${userId}`);
             socket = io({
                 query: { userId },
-                transports: ['websocket', 'polling'],
+                transports: ['polling'], // Force polling for Vercel compatibility
                 reconnection: true,
                 reconnectionAttempts: 10,
                 reconnectionDelay: 1000,
                 reconnectionDelayMax: 5000,
-                timeout: 20000
+                timeout: 20000,
+                upgrade: false // Don't try to upgrade to websocket
             });
             
             socket.on('connect', () => {

--- a/v2/public-v2/index.html
+++ b/v2/public-v2/index.html
@@ -350,15 +350,16 @@
             updateGameState(gameData.initialState);
             updateRoom(gameData.currentRoom);
             
-            // Connect socket with better configuration
+            // Connect socket with Vercel-compatible configuration (polling only)
             socket = io({
                 query: { userId },
-                transports: ['websocket', 'polling'],
+                transports: ['polling'], // Force polling for Vercel compatibility
                 reconnection: true,
                 reconnectionAttempts: 10,
                 reconnectionDelay: 1000,
                 reconnectionDelayMax: 5000,
-                timeout: 20000
+                timeout: 20000,
+                upgrade: false // Don't try to upgrade to websocket
             });
             
             socket.on('connect', () => {


### PR DESCRIPTION
Fixes WebSocket TransportError by forcing polling-only transport mode which is compatible with Vercel's serverless architecture