### PR TITLE
Fix Vercel deployment - Export Express app properly

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,11 +8,20 @@
   ],
   "routes": [
     {
+      "src": "/v2/api/(.*)",
+      "dest": "/index.js"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.js"
     }
   ],
   "env": {
     "NODE_ENV": "production"
+  },
+  "functions": {
+    "index.js": {
+      "maxDuration": 30
+    }
   }
 }


### PR DESCRIPTION
## Critical Vercel Fix
The API routes were returning 404 because the Express app wasn't being exported for Vercel's serverless environment.

## Changes
- Added `module.exports = app` to export Express app
- Only create HTTP server and Socket.IO when not in Vercel
- Added explicit route configuration in vercel.json
- Added test endpoint for debugging
- Added maxDuration setting for functions

## Testing
After deployment, test these endpoints:
- https://grue.is/v2/api/test (should return JSON with status: ok)