### PR TITLE
Use Vercel API routes for v2 endpoints

### DIFF
--- a/api/test.js
+++ b/api/test.js
@@ -1,0 +1,9 @@
+// Direct Vercel API route - bypasses Express
+export default function handler(req, res) {
+  res.status(200).json({
+    message: 'Direct Vercel API route works!',
+    path: req.url,
+    method: req.method,
+    timestamp: new Date().toISOString()
+  });
+}

--- a/api/v2/api/check-usage.js
+++ b/api/v2/api/check-usage.js
@@ -1,0 +1,47 @@
+// Vercel function for /api/v2/api/check-usage
+export default async function handler(req, res) {
+  try {
+    const startTime = Math.floor(Date.now() / 1000) - 86400; // Last 24 hours
+    
+    console.log("[V2] Checking OpenAI API usage...");
+    
+    const response = await fetch("https://api.openai.com/v1/organization/usage/completions?" + 
+      new URLSearchParams({
+        start_time: startTime,
+        limit: 1,
+        bucket_width: "1d"
+      }), {
+      headers: {
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json'
+      }
+    });
+    
+    const data = await response.json();
+    
+    const usage = {
+      apiKeyWorking: response.ok,
+      statusCode: response.status,
+      data: data
+    };
+    
+    if (data && data.data && data.data[0] && data.data[0].results && data.data[0].results[0]) {
+      const result = data.data[0].results[0];
+      usage.tokens = {
+        input: result.input_tokens || 0,
+        output: result.output_tokens || 0,
+        cached: result.input_cached_tokens || 0,
+        requests: result.num_model_requests || 0
+      };
+    }
+    
+    res.json(usage);
+  } catch (error) {
+    console.error("[V2] Error checking OpenAI usage:", error);
+    res.status(500).json({ 
+      error: "Failed to check usage",
+      message: error.message,
+      apiKeyWorking: false 
+    });
+  }
+}

--- a/api/v2/api/test.js
+++ b/api/v2/api/test.js
@@ -1,0 +1,8 @@
+// Direct Vercel API route for /api/v2/api/test
+export default function handler(req, res) {
+  res.status(200).json({
+    status: 'ok',
+    message: 'V2 API test endpoint (Vercel direct)',
+    timestamp: new Date().toISOString()
+  });
+}

--- a/index.js
+++ b/index.js
@@ -36,6 +36,21 @@ const {
 const app = express();
 const PORT = 3000;
 
+// VERY FIRST ROUTE - Test if ANY routing works
+app.get('/test-route', (req, res) => {
+  res.json({ 
+    message: 'Test route works!',
+    timestamp: new Date().toISOString(),
+    headers: req.headers
+  });
+});
+
+// Log all incoming requests for debugging
+app.use((req, res, next) => {
+  console.log(`[Request] ${req.method} ${req.url}`);
+  next();
+});
+
 const openai = new OpenAIApi(process.env.OPENAI_API_KEY);
 
 app.use(express.json());

--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,18 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "index.js",
-      "use": "@vercel/node"
+  "functions": {
+    "api/**/*.js": {
+      "maxDuration": 30
     }
-  ],
+  },
   "rewrites": [
     {
-      "source": "/(.*)",
-      "destination": "/index.js"
+      "source": "/v2/api/:path*",
+      "destination": "/api/v2/api/:path*"
+    },
+    {
+      "source": "/test-route",
+      "destination": "/api/test"
     }
   ],
   "env": {


### PR DESCRIPTION
Switch from Express routes to Vercel's native API routes in /api folder