### PR TITLE
Fix serverless crashes - use CommonJS

### DIFF
--- a/api/test.js
+++ b/api/test.js
@@ -1,5 +1,5 @@
 // Direct Vercel API route - bypasses Express
-export default function handler(req, res) {
+module.exports = function handler(req, res) {
   res.status(200).json({
     message: 'Direct Vercel API route works!',
     path: req.url,

--- a/api/v2/api/check-usage.js
+++ b/api/v2/api/check-usage.js
@@ -1,5 +1,5 @@
 // Vercel function for /api/v2/api/check-usage
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   try {
     const startTime = Math.floor(Date.now() / 1000) - 86400; // Last 24 hours
     

--- a/api/v2/api/continue-game.js
+++ b/api/v2/api/continue-game.js
@@ -1,5 +1,5 @@
 // Vercel function for /api/v2/api/continue-game
-import admin from 'firebase-admin';
+const admin = require('firebase-admin');
 
 // Initialize Firebase Admin if not already initialized
 const V2_APP_NAME = 'grue-v2-app';
@@ -46,7 +46,7 @@ async function loadGameFromFirebase(userId) {
   }
 }
 
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/api/v2/api/new-game.js
+++ b/api/v2/api/new-game.js
@@ -1,7 +1,7 @@
 // Vercel function for /api/v2/api/new-game
-import { createCompletePlan } from '../../../v2/game-planner.js';
-import { generateWorldWithoutImages } from '../../../v2/world-generator-fast.js';
-import admin from 'firebase-admin';
+const { createCompletePlan } = require('../../../v2/game-planner.js');
+const { generateWorldWithoutImages } = require('../../../v2/world-generator-fast.js');
+const admin = require('firebase-admin');
 
 // Initialize Firebase Admin if not already initialized
 const V2_APP_NAME = 'grue-v2-app';
@@ -46,7 +46,7 @@ async function saveGameToFirebase(userId, gameData) {
   }
 }
 
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }

--- a/api/v2/api/test.js
+++ b/api/v2/api/test.js
@@ -1,5 +1,5 @@
 // Direct Vercel API route for /api/v2/api/test
-export default function handler(req, res) {
+module.exports = function handler(req, res) {
   res.status(200).json({
     status: 'ok',
     message: 'V2 API test endpoint (Vercel direct)',


### PR DESCRIPTION
Fix 500 errors by using CommonJS syntax instead of ES6 modules